### PR TITLE
Update python-nest dependency for Nest Protect support

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -4,4 +4,4 @@ cement==2.6.2
 requests==2.7.0
 pysnmp==4.2.5
 colorlog==2.6.0
-python-nest==2.6.0
+python-nest==2.7.0


### PR DESCRIPTION
Update python-next dependency to 2.7.0 to include Nest protect support
